### PR TITLE
Simplify system catalog introspection on behalf of CRDB.

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -94,10 +94,7 @@ class Connection(metaclass=ConnectionMeta):
         self._server_caps = _detect_server_capabilities(
             self._server_version, settings)
 
-        if self._server_version < (14, 0):
-            self._intro_query = introspection.INTRO_LOOKUP_TYPES_13
-        else:
-            self._intro_query = introspection.INTRO_LOOKUP_TYPES
+        self._intro_query = introspection.INTRO_LOOKUP_TYPES_CRDB
 
         self._reset_query = None
         self._proxy = None

--- a/asyncpg/introspection.py
+++ b/asyncpg/introspection.py
@@ -5,246 +5,28 @@
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
 
-_TYPEINFO_13 = '''\
-    (
-        SELECT
-            t.oid                           AS oid,
-            ns.nspname                      AS ns,
-            t.typname                       AS name,
-            t.typtype                       AS kind,
-            (CASE WHEN t.typtype = 'd' THEN
-                (WITH RECURSIVE typebases(oid, depth) AS (
-                    SELECT
-                        t2.typbasetype      AS oid,
-                        0                   AS depth
-                    FROM
-                        pg_type t2
-                    WHERE
-                        t2.oid = t.oid
-
-                    UNION ALL
-
-                    SELECT
-                        t2.typbasetype      AS oid,
-                        tb.depth + 1        AS depth
-                    FROM
-                        pg_type t2,
-                        typebases tb
-                    WHERE
-                       tb.oid = t2.oid
-                       AND t2.typbasetype != 0
-               ) SELECT oid FROM typebases ORDER BY depth DESC LIMIT 1)
-
-               ELSE NULL
-            END)                            AS basetype,
-            t.typelem                       AS elemtype,
-            elem_t.typdelim                 AS elemdelim,
-            range_t.rngsubtype              AS range_subtype,
-            (CASE WHEN t.typtype = 'c' THEN
-                (SELECT
-                    array_agg(ia.atttypid ORDER BY ia.attnum)
-                FROM
-                    pg_attribute ia
-                    INNER JOIN pg_class c
-                        ON (ia.attrelid = c.oid)
-                WHERE
-                    ia.attnum > 0 AND NOT ia.attisdropped
-                    AND c.reltype = t.oid)
-
-                ELSE NULL
-            END)                            AS attrtypoids,
-            (CASE WHEN t.typtype = 'c' THEN
-                (SELECT
-                    array_agg(ia.attname::text ORDER BY ia.attnum)
-                FROM
-                    pg_attribute ia
-                    INNER JOIN pg_class c
-                        ON (ia.attrelid = c.oid)
-                WHERE
-                    ia.attnum > 0 AND NOT ia.attisdropped
-                    AND c.reltype = t.oid)
-
-                ELSE NULL
-            END)                            AS attrnames
-        FROM
-            pg_catalog.pg_type AS t
-            INNER JOIN pg_catalog.pg_namespace ns ON (
-                ns.oid = t.typnamespace)
-            LEFT JOIN pg_type elem_t ON (
-                t.typlen = -1 AND
-                t.typelem != 0 AND
-                t.typelem = elem_t.oid
-            )
-            LEFT JOIN pg_range range_t ON (
-                t.oid = range_t.rngtypid
-            )
-    )
-'''
-
-
-INTRO_LOOKUP_TYPES_13 = '''\
-WITH RECURSIVE typeinfo_tree(
-    oid, ns, name, kind, basetype, elemtype, elemdelim,
-    range_subtype, attrtypoids, attrnames, depth)
-AS (
-    SELECT
-        ti.oid, ti.ns, ti.name, ti.kind, ti.basetype,
-        ti.elemtype, ti.elemdelim, ti.range_subtype,
-        ti.attrtypoids, ti.attrnames, 0
-    FROM
-        {typeinfo} AS ti
-    WHERE
-        ti.oid = any($1::oid[])
-
-    UNION ALL
-
-    SELECT
-        ti.oid, ti.ns, ti.name, ti.kind, ti.basetype,
-        ti.elemtype, ti.elemdelim, ti.range_subtype,
-        ti.attrtypoids, ti.attrnames, tt.depth + 1
-    FROM
-        {typeinfo} ti,
-        typeinfo_tree tt
-    WHERE
-        (tt.elemtype IS NOT NULL AND ti.oid = tt.elemtype)
-        OR (tt.attrtypoids IS NOT NULL AND ti.oid = any(tt.attrtypoids))
-        OR (tt.range_subtype IS NOT NULL AND ti.oid = tt.range_subtype)
-)
-
-SELECT DISTINCT
-    *,
-    basetype::regtype::text AS basetype_name,
-    elemtype::regtype::text AS elemtype_name,
-    range_subtype::regtype::text AS range_subtype_name
+INTRO_LOOKUP_TYPES_CRDB = """\
+SELECT
+    t.oid                           AS oid,
+    ns.nspname                      AS ns,
+    t.typname                       AS name,
+    t.typtype                       AS kind,
+    NULL                            AS basetype,
+    t.typelem                       AS elemtype,
+    NULL                            AS elemdelim,
+    NULL                            AS range_subtype,
+    NULL                            AS attrtypoids,
+    NULL                            AS attrnames,
+    NULL                            AS basetype_name,
+    '-'                             AS elemtype_name,
+    NULL                            AS range_subtype_name
 FROM
-    typeinfo_tree
-ORDER BY
-    depth DESC
-'''.format(typeinfo=_TYPEINFO_13)
-
-
-_TYPEINFO = '''\
-    (
-        SELECT
-            t.oid                           AS oid,
-            ns.nspname                      AS ns,
-            t.typname                       AS name,
-            t.typtype                       AS kind,
-            (CASE WHEN t.typtype = 'd' THEN
-                (WITH RECURSIVE typebases(oid, depth) AS (
-                    SELECT
-                        t2.typbasetype      AS oid,
-                        0                   AS depth
-                    FROM
-                        pg_type t2
-                    WHERE
-                        t2.oid = t.oid
-
-                    UNION ALL
-
-                    SELECT
-                        t2.typbasetype      AS oid,
-                        tb.depth + 1        AS depth
-                    FROM
-                        pg_type t2,
-                        typebases tb
-                    WHERE
-                       tb.oid = t2.oid
-                       AND t2.typbasetype != 0
-               ) SELECT oid FROM typebases ORDER BY depth DESC LIMIT 1)
-
-               ELSE NULL
-            END)                            AS basetype,
-            t.typelem                       AS elemtype,
-            elem_t.typdelim                 AS elemdelim,
-            COALESCE(
-                range_t.rngsubtype,
-                multirange_t.rngsubtype)    AS range_subtype,
-            (CASE WHEN t.typtype = 'c' THEN
-                (SELECT
-                    array_agg(ia.atttypid ORDER BY ia.attnum)
-                FROM
-                    pg_attribute ia
-                    INNER JOIN pg_class c
-                        ON (ia.attrelid = c.oid)
-                WHERE
-                    ia.attnum > 0 AND NOT ia.attisdropped
-                    AND c.reltype = t.oid)
-
-                ELSE NULL
-            END)                            AS attrtypoids,
-            (CASE WHEN t.typtype = 'c' THEN
-                (SELECT
-                    array_agg(ia.attname::text ORDER BY ia.attnum)
-                FROM
-                    pg_attribute ia
-                    INNER JOIN pg_class c
-                        ON (ia.attrelid = c.oid)
-                WHERE
-                    ia.attnum > 0 AND NOT ia.attisdropped
-                    AND c.reltype = t.oid)
-
-                ELSE NULL
-            END)                            AS attrnames
-        FROM
-            pg_catalog.pg_type AS t
-            INNER JOIN pg_catalog.pg_namespace ns ON (
-                ns.oid = t.typnamespace)
-            LEFT JOIN pg_type elem_t ON (
-                t.typlen = -1 AND
-                t.typelem != 0 AND
-                t.typelem = elem_t.oid
-            )
-            LEFT JOIN pg_range range_t ON (
-                t.oid = range_t.rngtypid
-            )
-            LEFT JOIN pg_range multirange_t ON (
-                t.oid = multirange_t.rngmultitypid
-            )
-    )
-'''
-
-
-INTRO_LOOKUP_TYPES = '''\
-WITH RECURSIVE typeinfo_tree(
-    oid, ns, name, kind, basetype, elemtype, elemdelim,
-    range_subtype, attrtypoids, attrnames, depth)
-AS (
-    SELECT
-        ti.oid, ti.ns, ti.name, ti.kind, ti.basetype,
-        ti.elemtype, ti.elemdelim, ti.range_subtype,
-        ti.attrtypoids, ti.attrnames, 0
-    FROM
-        {typeinfo} AS ti
-    WHERE
-        ti.oid = any($1::oid[])
-
-    UNION ALL
-
-    SELECT
-        ti.oid, ti.ns, ti.name, ti.kind, ti.basetype,
-        ti.elemtype, ti.elemdelim, ti.range_subtype,
-        ti.attrtypoids, ti.attrnames, tt.depth + 1
-    FROM
-        {typeinfo} ti,
-        typeinfo_tree tt
-    WHERE
-        (tt.elemtype IS NOT NULL AND ti.oid = tt.elemtype)
-        OR (tt.attrtypoids IS NOT NULL AND ti.oid = any(tt.attrtypoids))
-        OR (tt.range_subtype IS NOT NULL AND ti.oid = tt.range_subtype)
-)
-
-SELECT DISTINCT
-    *,
-    basetype::regtype::text AS basetype_name,
-    elemtype::regtype::text AS elemtype_name,
-    range_subtype::regtype::text AS range_subtype_name
-FROM
-    typeinfo_tree
-ORDER BY
-    depth DESC
-'''.format(typeinfo=_TYPEINFO)
-
+    pg_catalog.pg_type AS t
+    JOIN pg_catalog.pg_namespace ns
+        ON (ns.oid = t.typnamespace)
+WHERE
+        t.oid = any($1::oid[])
+"""
 
 TYPE_BY_NAME = '''\
 SELECT


### PR DESCRIPTION
Avoids 'cannot decorrelate query' coming back from CRDB when a user-defined type is encountered, until at least:

  * https://github.com/cockroachdb/cockroach/pull/81706
  * https://github.com/cockroachdb/cockroach/issues/80169
 
are solved.

Is good enough to introspect into enums at least.