### PR TITLE
Check whether on_data future is done before setting result/exception

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402,E731,W503,W504,E252
-exclude = .git,__pycache__,build,dist,.eggs,.github,.local
+exclude = .git,__pycache__,build,dist,.eggs,.github,.local,.venv

--- a/.github/workflows/install-postgres.sh
+++ b/.github/workflows/install-postgres.sh
@@ -27,11 +27,16 @@ if [ "${ID}" = "debian" -o "${ID}" = "ubuntu" ]; then
     apt-get install -y --no-install-recommends \
         "postgresql-${PGVERSION}" \
         "postgresql-contrib-${PGVERSION}"
+elif [ "${ID}" = "almalinux" ]; then
+    yum install -y \
+        "postgresql-server" \
+        "postgresql-devel" \
+        "postgresql-contrib"
 elif [ "${ID}" = "centos" ]; then
-    el="EL-${VERSION_ID}-$(arch)"
+    el="EL-${VERSION_ID%.*}-$(arch)"
     baseurl="https://download.postgresql.org/pub/repos/yum/reporpms"
     yum install -y "${baseurl}/${el}/pgdg-redhat-repo-latest.noarch.rpm"
-    if [ ${VERSION_ID} -ge 8 ]; then
+    if [ ${VERSION_ID%.*} -ge 8 ]; then
         dnf -qy module disable postgresql
     fi
     yum install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,6 @@ jobs:
   build-wheels:
     needs: build-wheels-matrix
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     name: Build ${{ matrix.only }}
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir -p dist/
         echo "${VERSION}" > dist/VERSION
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist/
@@ -50,7 +50,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
@@ -63,7 +63,7 @@ jobs:
         pip install -U setuptools wheel pip
         python setup.py sdist
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist/*.tar.*
@@ -74,7 +74,7 @@ jobs:
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - run: pip install cibuildwheel==2.10.2
       - id: set-matrix
@@ -86,7 +86,7 @@ jobs:
               && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
-          echo ::set-output name=include::"$MATRIX_INCLUDE"
+          echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
 
   build-wheels:
     needs: build-wheels-matrix
@@ -106,11 +106,11 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
-        
+
     - name: Set up QEMU
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
@@ -123,7 +123,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: wheelhouse/*.whl
@@ -137,7 +137,7 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 5
         submodules: true
@@ -153,7 +153,7 @@ jobs:
         make htmldocs
 
     - name: Checkout gh-pages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 5
         ref: gh-pages
@@ -179,12 +179,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 5
         submodules: false
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist/
@@ -193,7 +193,7 @@ jobs:
       id: relver
       run: |
         set -e
-        echo ::set-output name=version::$(cat dist/VERSION)
+        echo "version=$(cat dist/VERSION)" >> $GITHUB_OUTPUT
         rm dist/VERSION
 
     - name: Merge and tag the PR
@@ -219,7 +219,7 @@ jobs:
         ls -al dist/
 
     - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": inputs, "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": inputs, "os": "windows-latest"}'
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         fetch-depth: 50
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.2.2
+    - uses: pypa/cibuildwheel@v2.8.0
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BUILD: ${{ matrix.cibw_python }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Build source distribution
       run: |
@@ -68,19 +68,35 @@ jobs:
         name: dist
         path: dist/*.tar.*
 
-  build-wheels:
+  build-wheels-matrix:
     needs: validate-release-request
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+      - run: pip install cibuildwheel==2.10.2
+      - id: set-matrix
+        run: |
+          MATRIX_INCLUDE=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo ::set-output name=include::"$MATRIX_INCLUDE"
+
+  build-wheels:
+    needs: build-wheels-matrix
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    name: Build ${{ matrix.only }}
+
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        cibw_python: ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
-        cibw_arch: ["auto64", "auto32"]
-        exclude:
-          - os: macos-latest
-            cibw_arch: "auto32"
-          - os: ubuntu-latest
-            cibw_arch: "auto32"
+        include: ${{ fromJson(needs.build-wheels-matrix.outputs.include) }}
 
     defaults:
       run:
@@ -94,12 +110,18 @@ jobs:
       with:
         fetch-depth: 50
         submodules: true
+        
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v2
 
-    - uses: pypa/cibuildwheel@v2.8.0
+    - uses: pypa/cibuildwheel@v2.10.2
+      with:
+        only: ${{ matrix.only }}
       env:
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_BUILD: ${{ matrix.cibw_python }}
-        CIBW_ARCHS: ${{ matrix.cibw_arch }}
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 
     - uses: actions/upload-artifact@v2
       with:
@@ -107,7 +129,7 @@ jobs:
         path: wheelhouse/*.whl
 
   publish-docs:
-    needs: validate-release-request
+    needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
 
     env:
@@ -121,7 +143,7 @@ jobs:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
 
     - name: Build source distribution
       run: |
@@ -76,6 +78,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
       - run: pip install cibuildwheel==2.10.2
       - id: set-matrix
         run: |
@@ -144,7 +148,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.x"
 
     - name: Build docs
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:
@@ -35,7 +35,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
@@ -51,7 +51,7 @@ jobs:
           __version__\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: steps.release.outputs.version == 0
       with:
         python-version: ${{ matrix.python-version }}
@@ -76,7 +76,7 @@ jobs:
   test-postgres:
     strategy:
       matrix:
-        postgres-version: ["9.5", "9.6", "10", "11", "12", "13", "14"]
+        postgres-version: ["9.5", "9.6", "10", "11", "12", "13", "14", "15"]
 
     runs-on: ubuntu-latest
 
@@ -84,7 +84,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
@@ -111,7 +111,7 @@ jobs:
           >> "${GITHUB_ENV}"
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: steps.release.outputs.version == 0
 
     - name: Install Python Deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,10 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:
-          # uvloop does not support Python 3.6
-          - loop: uvloop
-            python-version: "3.6"
           # uvloop does not support windows
           - loop: uvloop
             os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,8 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       if: steps.release.outputs.version == 0
+      with:
+        python-version: "3.x"
 
     - name: Install Python Deps
       if: steps.release.outputs.version == 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ framework.  You can read more about asyncpg in an introductory
 `blog post <http://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/>`_.
 
 asyncpg requires Python 3.7 or later and is supported for PostgreSQL
-versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
+versions 9.5 to 15.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.  You can read more about asyncpg in an introductory
 `blog post <http://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/>`_.
 
-asyncpg requires Python 3.6 or later and is supported for PostgreSQL
+asyncpg requires Python 3.7 or later and is supported for PostgreSQL
 versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/asyncpg/_testbase/__init__.py
+++ b/asyncpg/_testbase/__init__.py
@@ -435,3 +435,93 @@ class ConnectedTestCase(ClusterTestCase):
             self.con = None
         finally:
             super().tearDown()
+
+
+class HotStandbyTestCase(ClusterTestCase):
+
+    @classmethod
+    def setup_cluster(cls):
+        cls.master_cluster = cls.new_cluster(pg_cluster.TempCluster)
+        cls.start_cluster(
+            cls.master_cluster,
+            server_settings={
+                'max_wal_senders': 10,
+                'wal_level': 'hot_standby'
+            }
+        )
+
+        con = None
+
+        try:
+            con = cls.loop.run_until_complete(
+                cls.master_cluster.connect(
+                    database='postgres', user='postgres', loop=cls.loop))
+
+            cls.loop.run_until_complete(
+                con.execute('''
+                    CREATE ROLE replication WITH LOGIN REPLICATION
+                '''))
+
+            cls.master_cluster.trust_local_replication_by('replication')
+
+            conn_spec = cls.master_cluster.get_connection_spec()
+
+            cls.standby_cluster = cls.new_cluster(
+                pg_cluster.HotStandbyCluster,
+                cluster_kwargs={
+                    'master': conn_spec,
+                    'replication_user': 'replication'
+                }
+            )
+            cls.start_cluster(
+                cls.standby_cluster,
+                server_settings={
+                    'hot_standby': True
+                }
+            )
+
+        finally:
+            if con is not None:
+                cls.loop.run_until_complete(con.close())
+
+    @classmethod
+    def get_cluster_connection_spec(cls, cluster, kwargs={}):
+        conn_spec = cluster.get_connection_spec()
+        if kwargs.get('dsn'):
+            conn_spec.pop('host')
+        conn_spec.update(kwargs)
+        if not os.environ.get('PGHOST') and not kwargs.get('dsn'):
+            if 'database' not in conn_spec:
+                conn_spec['database'] = 'postgres'
+            if 'user' not in conn_spec:
+                conn_spec['user'] = 'postgres'
+        return conn_spec
+
+    @classmethod
+    def get_connection_spec(cls, kwargs={}):
+        primary_spec = cls.get_cluster_connection_spec(
+            cls.master_cluster, kwargs
+        )
+        standby_spec = cls.get_cluster_connection_spec(
+            cls.standby_cluster, kwargs
+        )
+        return {
+            'host': [primary_spec['host'], standby_spec['host']],
+            'port': [primary_spec['port'], standby_spec['port']],
+            'database': primary_spec['database'],
+            'user': primary_spec['user'],
+            **kwargs
+        }
+
+    @classmethod
+    def connect_primary(cls, **kwargs):
+        conn_spec = cls.get_cluster_connection_spec(cls.master_cluster, kwargs)
+        return pg_connection.connect(**conn_spec, loop=cls.loop)
+
+    @classmethod
+    def connect_standby(cls, **kwargs):
+        conn_spec = cls.get_cluster_connection_spec(
+            cls.standby_cluster,
+            kwargs
+        )
+        return pg_connection.connect(**conn_spec, loop=cls.loop)

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.26.0.dev0'
+__version__ = '0.26.0'

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.27.0.dev0'
+__version__ = '0.28.0.dev0'

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.26.0'
+__version__ = '0.27.0'

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.27.0'
+__version__ = '0.27.0.dev0'

--- a/asyncpg/cluster.py
+++ b/asyncpg/cluster.py
@@ -626,7 +626,7 @@ class HotStandbyCluster(TempCluster):
                 'pg_basebackup init exited with status {:d}:\n{}'.format(
                     process.returncode, output.decode()))
 
-        if self._pg_version <= (11, 0):
+        if self._pg_version < (12, 0):
             with open(os.path.join(self._data_dir, 'recovery.conf'), 'w') as f:
                 f.write(textwrap.dedent("""\
                     standby_mode = 'on'

--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -8,6 +8,7 @@
 import asyncio
 import pathlib
 import platform
+import typing
 
 
 SYSTEM = platform.uname().system
@@ -18,7 +19,7 @@ if SYSTEM == 'Windows':
 
     CSIDL_APPDATA = 0x001a
 
-    def get_pg_home_directory() -> pathlib.Path:
+    def get_pg_home_directory() -> typing.Optional[pathlib.Path]:
         # We cannot simply use expanduser() as that returns the user's
         # home directory, whereas Postgres stores its config in
         # %AppData% on Windows.
@@ -30,8 +31,11 @@ if SYSTEM == 'Windows':
             return pathlib.Path(buf.value) / 'postgresql'
 
 else:
-    def get_pg_home_directory() -> pathlib.Path:
-        return pathlib.Path.home()
+    def get_pg_home_directory() -> typing.Optional[pathlib.Path]:
+        try:
+            return pathlib.Path.home()
+        except (RuntimeError, KeyError):
+            return None
 
 
 async def wait_closed(stream):

--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -8,10 +8,8 @@
 import asyncio
 import pathlib
 import platform
-import sys
 
 
-PY_37 = sys.version_info >= (3, 7)
 SYSTEM = platform.uname().system
 
 
@@ -34,14 +32,6 @@ if SYSTEM == 'Windows':
 else:
     def get_pg_home_directory() -> pathlib.Path:
         return pathlib.Path.home()
-
-
-if PY_37:
-    def current_asyncio_task(loop):
-        return asyncio.current_task(loop)
-else:
-    def current_asyncio_task(loop):
-        return asyncio.Task.current_task(loop)
 
 
 async def wait_closed(stream):

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -249,8 +249,13 @@ def _parse_tls_version(tls_version):
         )
 
 
-def _dot_postgresql_path(filename) -> pathlib.Path:
-    return (pathlib.Path.home() / '.postgresql' / filename).resolve()
+def _dot_postgresql_path(filename) -> typing.Optional[pathlib.Path]:
+    try:
+        homedir = pathlib.Path.home()
+    except (RuntimeError, KeyError):
+        return None
+
+    return (homedir / '.postgresql' / filename).resolve()
 
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
@@ -501,11 +506,16 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                     ssl.load_verify_locations(cafile=sslrootcert)
                     ssl.verify_mode = ssl_module.CERT_REQUIRED
                 else:
-                    sslrootcert = _dot_postgresql_path('root.crt')
                     try:
+                        sslrootcert = _dot_postgresql_path('root.crt')
+                        assert sslrootcert is not None
                         ssl.load_verify_locations(cafile=sslrootcert)
-                    except FileNotFoundError:
+                    except (AssertionError, FileNotFoundError):
                         if sslmode > SSLMode.require:
+                            if sslrootcert is None:
+                                raise RuntimeError(
+                                    'Cannot determine home directory'
+                                )
                             raise ValueError(
                                 f'root certificate file "{sslrootcert}" does '
                                 f'not exist\nEither provide the file or '
@@ -526,18 +536,20 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                     ssl.verify_flags |= ssl_module.VERIFY_CRL_CHECK_CHAIN
                 else:
                     sslcrl = _dot_postgresql_path('root.crl')
-                    try:
-                        ssl.load_verify_locations(cafile=sslcrl)
-                    except FileNotFoundError:
-                        pass
-                    else:
-                        ssl.verify_flags |= ssl_module.VERIFY_CRL_CHECK_CHAIN
+                    if sslcrl is not None:
+                        try:
+                            ssl.load_verify_locations(cafile=sslcrl)
+                        except FileNotFoundError:
+                            pass
+                        else:
+                            ssl.verify_flags |= \
+                                ssl_module.VERIFY_CRL_CHECK_CHAIN
 
             if sslkey is None:
                 sslkey = os.getenv('PGSSLKEY')
             if not sslkey:
                 sslkey = _dot_postgresql_path('postgresql.key')
-                if not sslkey.exists():
+                if sslkey is not None and not sslkey.exists():
                     sslkey = None
             if not sslpassword:
                 sslpassword = ''
@@ -549,12 +561,15 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 )
             else:
                 sslcert = _dot_postgresql_path('postgresql.crt')
-                try:
-                    ssl.load_cert_chain(
-                        sslcert, keyfile=sslkey, password=lambda: sslpassword
-                    )
-                except FileNotFoundError:
-                    pass
+                if sslcert is not None:
+                    try:
+                        ssl.load_cert_chain(
+                            sslcert,
+                            keyfile=sslkey,
+                            password=lambda: sslpassword
+                        )
+                    except FileNotFoundError:
+                        pass
 
             # OpenSSL 1.1.1 keylog file, copied from create_default_context()
             if hasattr(ssl, 'keylog_filename'):

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -237,10 +237,6 @@ def _parse_hostlist(hostlist, port, *, unquote=False):
 
 
 def _parse_tls_version(tls_version):
-    if not hasattr(ssl_module, 'TLSVersion'):
-        raise ValueError(
-            "TLSVersion is not supported in this version of Python"
-        )
     if tls_version.startswith('SSL'):
         raise ValueError(
             f"Unsupported TLS version: {tls_version}"
@@ -573,11 +569,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                     ssl_min_protocol_version
                 )
             else:
-                try:
-                    ssl.minimum_version = _parse_tls_version('TLSv1.2')
-                except ValueError:
-                    # Python 3.6 does not have ssl.TLSVersion
-                    pass
+                ssl.minimum_version = _parse_tls_version('TLSv1.2')
 
             if ssl_max_protocol_version is None:
                 ssl_max_protocol_version = os.getenv('PGSSLMAXPROTOCOLVERSION')

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1416,6 +1416,7 @@ class Connection(metaclass=ConnectionMeta):
     def _maybe_gc_stmt(self, stmt):
         if (
             stmt.refs == 0
+            and stmt.name
             and not self._stmt_cache.has(
                 (stmt.query, stmt.record_class, stmt.ignore_custom_codec)
             )

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -20,7 +20,6 @@ import typing
 import warnings
 import weakref
 
-from . import compat
 from . import connect_utils
 from . import cursor
 from . import exceptions
@@ -1468,7 +1467,7 @@ class Connection(metaclass=ConnectionMeta):
                 waiter.set_exception(ex)
         finally:
             self._cancellations.discard(
-                compat.current_asyncio_task(self._loop))
+                asyncio.current_task(self._loop))
             if not waiter.done():
                 waiter.set_result(None)
 

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -2065,6 +2065,9 @@ async def connect(dsn=None, *,
        in the *dsn* argument now have consistent default values of files under
        ``~/.postgresql/`` as libpq.
 
+    .. versionchanged:: 0.26.0
+       Added the *direct_tls* parameter.
+
     .. _SSLContext: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
     .. _create_default_context:
         https://docs.python.org/3/library/ssl.html#ssl.create_default_context

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1792,7 +1792,8 @@ async def connect(dsn=None, *,
                   direct_tls=False,
                   connection_class=Connection,
                   record_class=protocol.Record,
-                  server_settings=None):
+                  server_settings=None,
+                  target_session_attrs=None):
     r"""A coroutine to establish a connection to a PostgreSQL server.
 
     The connection parameters may be specified either as a connection
@@ -2003,6 +2004,22 @@ async def connect(dsn=None, *,
         this connection object.  Must be a subclass of
         :class:`~asyncpg.Record`.
 
+    :param SessionAttribute target_session_attrs:
+        If specified, check that the host has the correct attribute.
+        Can be one of:
+            "any": the first successfully connected host
+            "primary": the host must NOT be in hot standby mode
+            "standby": the host must be in hot standby mode
+            "read-write": the host must allow writes
+            "read-only": the host most NOT allow writes
+            "prefer-standby": first try to find a standby host, but if
+                            none of the listed hosts is a standby server,
+                            return any of them.
+
+        If not specified will try to use PGTARGETSESSIONATTRS
+        from the environment.
+        Defaults to "any" if no value is set.
+
     :return: A :class:`~asyncpg.connection.Connection` instance.
 
     Example:
@@ -2109,6 +2126,7 @@ async def connect(dsn=None, *,
         statement_cache_size=statement_cache_size,
         max_cached_statement_lifetime=max_cached_statement_lifetime,
         max_cacheable_statement_size=max_cacheable_statement_size,
+        target_session_attrs=target_session_attrs
     )
 
 

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -13,7 +13,7 @@ import textwrap
 __all__ = ('PostgresError', 'FatalPostgresError', 'UnknownPostgresError',
            'InterfaceError', 'InterfaceWarning', 'PostgresLogMessage',
            'InternalClientError', 'OutdatedSchemaCacheError', 'ProtocolError',
-           'UnsupportedClientFeatureError')
+           'UnsupportedClientFeatureError', 'TargetServerAttributeNotMatched')
 
 
 def _is_asyncpg_class(cls):
@@ -242,6 +242,10 @@ class InternalClientError(Exception):
 
 class ProtocolError(InternalClientError):
     """Unexpected condition in the handling of PostgreSQL protocol input."""
+
+
+class TargetServerAttributeNotMatched(InternalClientError):
+    """Could not find a host that satisfies the target attribute requirement"""
 
 
 class OutdatedSchemaCacheError(InternalClientError):

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -43,10 +43,6 @@ class PoolConnectionProxyMeta(type):
 
         return super().__new__(mcls, name, bases, dct)
 
-    def __init__(cls, name, bases, dct, *, wrap=False):
-        # Needed for Python 3.5 to handle `wrap` class keyword argument.
-        super().__init__(name, bases, dct)
-
     @staticmethod
     def _wrap_connection_method(meth_name):
         def call_con_method(self, *args, **kwargs):

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -446,6 +446,13 @@ class Pool:
 
                 await asyncio.gather(*connect_tasks)
 
+    def is_closing(self):
+        """Return ``True`` if the pool is closing or is closed.
+
+        .. versionadded:: 0.28.0
+        """
+        return self._closed or self._closing
+
     def get_size(self):
         """Return the current number of connections in this pool.
 

--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -451,16 +451,31 @@ record_subscript(ApgRecordObject* o, PyObject* item)
 }
 
 
+static const char *
+get_typename(PyTypeObject *type)
+{
+    assert(type->tp_name != NULL);
+    const char *s = strrchr(type->tp_name, '.');
+    if (s == NULL) {
+        s = type->tp_name;
+    }
+    else {
+        s++;
+    }
+    return s;
+}
+
+
 static PyObject *
 record_repr(ApgRecordObject *v)
 {
     Py_ssize_t i, n;
-    PyObject *keys_iter;
+    PyObject *keys_iter, *type_prefix;
     _PyUnicodeWriter writer;
 
     n = Py_SIZE(v);
     if (n == 0) {
-        return PyUnicode_FromString("<Record>");
+        return PyUnicode_FromFormat("<%s>", get_typename(Py_TYPE(v)));
     }
 
     keys_iter = PyObject_GetIter(v->desc->keys);
@@ -471,16 +486,22 @@ record_repr(ApgRecordObject *v)
     i = Py_ReprEnter((PyObject *)v);
     if (i != 0) {
         Py_DECREF(keys_iter);
-        return i > 0 ? PyUnicode_FromString("<Record ...>") : NULL;
+        if (i > 0) {
+            return PyUnicode_FromFormat("<%s ...>", get_typename(Py_TYPE(v)));
+        }
+        return NULL;
     }
 
     _PyUnicodeWriter_Init(&writer);
     writer.overallocate = 1;
     writer.min_length = 12; /* <Record a=1> */
 
-    if (_PyUnicodeWriter_WriteASCIIString(&writer, "<Record ", 8) < 0) {
+    type_prefix = PyUnicode_FromFormat("<%s ", get_typename(Py_TYPE(v)));
+    if (_PyUnicodeWriter_WriteStr(&writer, type_prefix) < 0) {
+        Py_DECREF(type_prefix);
         goto error;
     }
+    Py_DECREF(type_prefix);
 
     for (i = 0; i < n; ++i) {
         PyObject *key;

--- a/asyncpg/protocol/scram.pyx
+++ b/asyncpg/protocol/scram.pyx
@@ -156,12 +156,12 @@ cdef class SCRAMAuthentication:
         if not self.server_nonce.startswith(self.client_nonce):
             raise Exception("invalid nonce")
         try:
-            self.password_salt = re.search(b's=([^,]+),',
+            self.password_salt = re.search(b',s=([^,]+),',
                 self.server_first_message).group(1)
         except IndexError:
             raise Exception("could not get salt")
         try:
-            self.password_iterations = int(re.search(b'i=(\d+),?',
+            self.password_iterations = int(re.search(b',i=(\d+),?',
                 self.server_first_message).group(1))
         except (IndexError, TypeError, ValueError):
             raise Exception("could not get iterations")

--- a/asyncpg/protocol/scram.pyx
+++ b/asyncpg/protocol/scram.pyx
@@ -9,17 +9,10 @@ import base64
 import hashlib
 import hmac
 import re
+import secrets
 import stringprep
 import unicodedata
 
-
-# try to import the secrets library from Python 3.6+ for the
-# cryptographic token generator for generating nonces as part of SCRAM
-# Otherwise fall back on os.urandom
-try:
-    from secrets import token_bytes as generate_token_bytes
-except ImportError:
-    from os import urandom as generate_token_bytes
 
 @cython.final
 cdef class SCRAMAuthentication:
@@ -198,7 +191,7 @@ cdef class SCRAMAuthentication:
         cdef:
             bytes token
 
-        token = generate_token_bytes(num_bytes)
+        token = secrets.token_bytes(num_bytes)
 
         return base64.b64encode(token)
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,6 +34,12 @@ class that implements dot-notation via the ``record_class`` argument to
 :func:`connect() <asyncpg.connection.connect>` or any of the Record-returning
 methods.
 
+.. code-block:: python
+
+    class MyRecord(asyncpg.Record):
+        def __getattr__(self, name):
+            return self[name]
+
 
 Why can't I use a :ref:`cursor <asyncpg-api-cursor>` outside of a transaction?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.
 
 **asyncpg** requires Python 3.7 or later and is supported for PostgreSQL
-versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
+versions 9.5 to 15.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 
 Contents

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ PostgreSQL and Python/asyncio.  asyncpg is an efficient, clean implementation
 of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.
 
-**asyncpg** requires Python 3.6 or later and is supported for PostgreSQL
+**asyncpg** requires Python 3.7 or later and is supported for PostgreSQL
 versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "asyncpg"
-requires-python = ">=3.6"
-
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Minimal dependencies required to test asyncpg.
 TEST_DEPENDENCIES = [
-    # pycodestyle is a dependency of flake8, but it must be frozen because
-    # their combination breaks too often
-    # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
-    'pycodestyle~=2.7.0',
-    'flake8~=3.9.2',
+    'flake8~=5.0.4',
     'uvloop>=0.15.3; platform_system != "Windows" and python_version >= "3.7"',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@
 
 import sys
 
-if sys.version_info < (3, 6):
-    raise RuntimeError('asyncpg requires Python 3.6 or greater')
+if sys.version_info < (3, 7):
+    raise RuntimeError('asyncpg requires Python 3.7 or greater')
 
 import os
 import os.path
@@ -30,7 +30,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 # Minimal dependencies required to test asyncpg.
 TEST_DEPENDENCIES = [
     'flake8~=5.0.4',
-    'uvloop>=0.15.3; platform_system != "Windows" and python_version >= "3.7"',
+    'uvloop>=0.15.3; platform_system != "Windows"',
 ]
 
 # Dependencies required to build documentation.
@@ -255,7 +255,6 @@ setuptools.setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -264,7 +263,7 @@ setuptools.setup(
         'Topic :: Database :: Front-Ends',
     ],
     platforms=['macOS', 'POSIX', 'Windows'],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     zip_safe=False,
     author='MagicStack Inc',
     author_email='hello@magic.io',

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1287,6 +1287,7 @@ class BaseTestSSLConnection(tb.ConnectedTestCase):
 
         create_script = []
         create_script.append('CREATE ROLE ssl_user WITH LOGIN;')
+        create_script.append('GRANT ALL ON SCHEMA public TO ssl_user;')
 
         self._add_hba_entry()
 
@@ -1301,6 +1302,7 @@ class BaseTestSSLConnection(tb.ConnectedTestCase):
         self.cluster.trust_local_connections()
 
         drop_script = []
+        drop_script.append('REVOKE ALL ON SCHEMA public FROM ssl_user;')
         drop_script.append('DROP ROLE ssl_user;')
         drop_script = '\n'.join(drop_script)
         self.loop.run_until_complete(self.con.execute(drop_script))
@@ -1461,7 +1463,7 @@ class TestSSLConnection(BaseTestSSLConnection):
             )
         finally:
             try:
-                await con.execute('DROP TABLE test_many')
+                await con.execute('DROP TABLE IF EXISTS test_many')
             finally:
                 await con.close()
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1497,13 +1497,14 @@ class TestSSLConnection(BaseTestSSLConnection):
                             '&ssl_min_protocol_version=TLSv1.1'
                             '&ssl_max_protocol_version=TLSv1.1'
                     )
-                with self.assertRaisesRegex(ssl.SSLError, 'no protocols'):
-                    await self.connect(
-                        dsn='postgresql://ssl_user@localhost/postgres'
-                            '?sslmode=require'
-                            '&ssl_min_protocol_version=TLSv1.2'
-                            '&ssl_max_protocol_version=TLSv1.1'
-                    )
+                if not ssl.OPENSSL_VERSION.startswith('LibreSSL'):
+                    with self.assertRaisesRegex(ssl.SSLError, 'no protocols'):
+                        await self.connect(
+                            dsn='postgresql://ssl_user@localhost/postgres'
+                                '?sslmode=require'
+                                '&ssl_min_protocol_version=TLSv1.2'
+                                '&ssl_max_protocol_version=TLSv1.1'
+                        )
                 con = await self.connect(
                     dsn='postgresql://ssl_user@localhost/postgres'
                         '?sslmode=require'

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -14,7 +14,6 @@ import platform
 import shutil
 import ssl
 import stat
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -1466,10 +1465,6 @@ class TestSSLConnection(BaseTestSSLConnection):
             finally:
                 await con.close()
 
-    @unittest.skipIf(
-        sys.version_info < (3, 7),
-        "Python < 3.7 doesn't have ssl.TLSVersion"
-    )
     async def test_tls_version(self):
         if self.cluster.get_pg_version() < (12, 0):
             self.skipTest("PostgreSQL < 12 cannot set ssl protocol version")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -24,7 +24,7 @@ import weakref
 
 import asyncpg
 from asyncpg import _testbase as tb
-from asyncpg import connection
+from asyncpg import connection as pg_connection
 from asyncpg import connect_utils
 from asyncpg import cluster as pg_cluster
 from asyncpg import exceptions
@@ -392,7 +392,8 @@ class TestConnectParams(tb.TestCase):
                 'password': 'passw',
                 'database': 'testdb',
                 'ssl': True,
-                'sslmode': SSLMode.prefer})
+                'sslmode': SSLMode.prefer,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -414,7 +415,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host2', 456)], {
                 'user': 'user2',
                 'password': 'passw2',
-                'database': 'db2'})
+                'database': 'db2',
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -442,7 +444,8 @@ class TestConnectParams(tb.TestCase):
                 'password': 'passw2',
                 'database': 'db2',
                 'sslmode': SSLMode.disable,
-                'ssl': False})
+                'ssl': False,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -463,7 +466,8 @@ class TestConnectParams(tb.TestCase):
                 'password': '123123',
                 'database': 'abcdef',
                 'ssl': True,
-                'sslmode': SSLMode.allow})
+                'sslmode': SSLMode.allow,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -491,7 +495,8 @@ class TestConnectParams(tb.TestCase):
                 'password': 'passw2',
                 'database': 'db2',
                 'sslmode': SSLMode.disable,
-                'ssl': False})
+                'ssl': False,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -512,7 +517,8 @@ class TestConnectParams(tb.TestCase):
                 'password': '123123',
                 'database': 'abcdef',
                 'ssl': True,
-                'sslmode': SSLMode.prefer})
+                'sslmode': SSLMode.prefer,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -521,7 +527,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('localhost', 5555)], {
                 'user': 'user3',
                 'password': '123123',
-                'database': 'abcdef'})
+                'database': 'abcdef',
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -530,6 +537,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host1', 5432), ('host2', 5432)], {
                 'database': 'db',
                 'user': 'user',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -539,6 +547,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host1', 1111), ('host2', 2222)], {
                 'database': 'db',
                 'user': 'user',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -548,6 +557,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('2001:db8::1234%eth0', 5432), ('::1', 5432)], {
                 'database': 'db',
                 'user': 'user',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -557,6 +567,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('2001:db8::1234', 1111), ('::1', 2222)], {
                 'database': 'db',
                 'user': 'user',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -566,6 +577,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('2001:db8::1234', 5432), ('::1', 5432)], {
                 'database': 'db',
                 'user': 'user',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -580,6 +592,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host1', 1111), ('host2', 2222)], {
                 'database': 'db',
                 'user': 'foo',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -592,6 +605,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host1', 1111), ('host2', 2222)], {
                 'database': 'db',
                 'user': 'foo',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -605,6 +619,7 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host1', 5432), ('host2', 5432)], {
                 'database': 'db',
                 'user': 'foo',
+                'target_session_attrs': 'any',
             })
         },
 
@@ -624,7 +639,8 @@ class TestConnectParams(tb.TestCase):
                 'password': 'ask',
                 'database': 'db',
                 'ssl': True,
-                'sslmode': SSLMode.require})
+                'sslmode': SSLMode.require,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -645,7 +661,8 @@ class TestConnectParams(tb.TestCase):
                 'password': 'ask',
                 'database': 'db',
                 'sslmode': SSLMode.verify_full,
-                'ssl': True})
+                'ssl': True,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -653,7 +670,8 @@ class TestConnectParams(tb.TestCase):
             'dsn': 'postgresql:///dbname?host=/unix_sock/test&user=spam',
             'result': ([os.path.join('/unix_sock/test', '.s.PGSQL.5432')], {
                 'user': 'spam',
-                'database': 'dbname'})
+                'database': 'dbname',
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -665,6 +683,7 @@ class TestConnectParams(tb.TestCase):
                     'user': 'us@r',
                     'password': 'p@ss',
                     'database': 'db',
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -678,6 +697,7 @@ class TestConnectParams(tb.TestCase):
                     'user': 'user',
                     'password': 'p',
                     'database': 'db',
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -690,6 +710,7 @@ class TestConnectParams(tb.TestCase):
                 {
                     'user': 'us@r',
                     'database': 'db',
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -717,7 +738,8 @@ class TestConnectParams(tb.TestCase):
                     'user': 'user',
                     'database': 'user',
                     'sslmode': SSLMode.disable,
-                    'ssl': None
+                    'ssl': None,
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -731,7 +753,8 @@ class TestConnectParams(tb.TestCase):
                     '.s.PGSQL.5432'
                 )], {
                     'user': 'spam',
-                    'database': 'db'
+                    'database': 'db',
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -752,6 +775,7 @@ class TestConnectParams(tb.TestCase):
                     'database': 'db',
                     'ssl': True,
                     'sslmode': SSLMode.prefer,
+                    'target_session_attrs': 'any',
                 }
             )
         },
@@ -796,6 +820,7 @@ class TestConnectParams(tb.TestCase):
         database = testcase.get('database')
         sslmode = testcase.get('ssl')
         server_settings = testcase.get('server_settings')
+        target_session_attrs = testcase.get('target_session_attrs')
 
         expected = testcase.get('result')
         expected_error = testcase.get('error')
@@ -819,7 +844,8 @@ class TestConnectParams(tb.TestCase):
                 dsn=dsn, host=host, port=port, user=user, password=password,
                 passfile=passfile, database=database, ssl=sslmode,
                 direct_tls=False, connect_timeout=None,
-                server_settings=server_settings)
+                server_settings=server_settings,
+                target_session_attrs=target_session_attrs)
 
             params = {
                 k: v for k, v in params._asdict().items()
@@ -880,7 +906,9 @@ class TestConnectParams(tb.TestCase):
                 'host': 'abc',
                 'result': (
                     [('abc', 5432)],
-                    {'user': '__test__', 'database': '__test__'}
+                    {'user': '__test__',
+                     'database': '__test__',
+                     'target_session_attrs': 'any'}
                 )
             })
 
@@ -918,6 +946,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -934,6 +963,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -948,6 +978,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -963,6 +994,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for localhost',
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -980,6 +1012,7 @@ class TestConnectParams(tb.TestCase):
                             'password': 'password from pgpass for localhost',
                             'user': 'user',
                             'database': 'db',
+                            'target_session_attrs': 'any',
                         }
                     )
                 })
@@ -997,6 +1030,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for cde:5433',
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -1013,6 +1047,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for testuser',
                         'user': 'testuser',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -1029,6 +1064,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for testdb',
                         'user': 'user',
                         'database': 'testdb',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -1045,6 +1081,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass with escapes',
                         'user': R'test\\',
                         'database': R'test\:db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -1072,6 +1109,7 @@ class TestConnectParams(tb.TestCase):
                         {
                             'user': 'user',
                             'database': 'db',
+                            'target_session_attrs': 'any',
                         }
                     )
                 })
@@ -1092,6 +1130,7 @@ class TestConnectParams(tb.TestCase):
                         {
                             'user': 'user',
                             'database': 'db',
+                            'target_session_attrs': 'any',
                         }
                     )
                 })
@@ -1108,6 +1147,7 @@ class TestConnectParams(tb.TestCase):
                 {
                     'user': 'user',
                     'database': 'db',
+                    'target_session_attrs': 'any',
                 }
             )
         })
@@ -1128,6 +1168,7 @@ class TestConnectParams(tb.TestCase):
                     {
                         'user': 'user',
                         'database': 'db',
+                        'target_session_attrs': 'any',
                     }
                 )
             })
@@ -1150,6 +1191,7 @@ class TestConnectParams(tb.TestCase):
                             {
                                 'user': 'user',
                                 'database': 'db',
+                                'target_session_attrs': 'any',
                             }
                         )
                     })
@@ -1172,7 +1214,7 @@ class TestConnectParams(tb.TestCase):
 class TestConnection(tb.ConnectedTestCase):
 
     async def test_connection_isinstance(self):
-        self.assertTrue(isinstance(self.con, connection.Connection))
+        self.assertTrue(isinstance(self.con, pg_connection.Connection))
         self.assertTrue(isinstance(self.con, object))
         self.assertFalse(isinstance(self.con, list))
 
@@ -1765,8 +1807,96 @@ class TestConnectionGC(tb.ClusterTestCase):
                                        r'unclosed connection') as rw:
                 await self._run_no_explicit_close_test()
 
-            msg = rw.warning.args[0]
+            msg = " ".join(rw.warning.args)
             self.assertIn(' created at:\n', msg)
             self.assertIn('in test_no_explicit_close_with_debug', msg)
         finally:
             self.loop.set_debug(olddebug)
+
+
+class TestConnectionAttributes(tb.HotStandbyTestCase):
+
+    async def _run_connection_test(
+        self, connect, target_attribute, expected_port
+    ):
+        conn = await connect(target_session_attrs=target_attribute)
+        self.assertTrue(_get_connected_host(conn).endswith(expected_port))
+        await conn.close()
+
+    async def test_target_server_attribute_port(self):
+        master_port = self.master_cluster.get_connection_spec()['port']
+        standby_port = self.standby_cluster.get_connection_spec()['port']
+        tests = [
+            (self.connect_primary, 'primary', master_port),
+            (self.connect_standby, 'standby', standby_port),
+        ]
+
+        for connect, target_attr, expected_port in tests:
+            await self._run_connection_test(
+                connect, target_attr, expected_port
+            )
+        if self.master_cluster.get_pg_version()[0] < 14:
+            self.skipTest("PostgreSQL<14 does not support these features")
+        tests = [
+            (self.connect_primary, 'read-write', master_port),
+            (self.connect_standby, 'read-only', standby_port),
+        ]
+
+        for connect, target_attr, expected_port in tests:
+            await self._run_connection_test(
+                connect, target_attr, expected_port
+            )
+
+    async def test_target_attribute_not_matched(self):
+        tests = [
+            (self.connect_standby, 'primary'),
+            (self.connect_primary, 'standby'),
+        ]
+
+        for connect, target_attr in tests:
+            with self.assertRaises(exceptions.TargetServerAttributeNotMatched):
+                await connect(target_session_attrs=target_attr)
+
+        if self.master_cluster.get_pg_version()[0] < 14:
+            self.skipTest("PostgreSQL<14 does not support these features")
+        tests = [
+            (self.connect_standby, 'read-write'),
+            (self.connect_primary, 'read-only'),
+        ]
+
+        for connect, target_attr in tests:
+            with self.assertRaises(exceptions.TargetServerAttributeNotMatched):
+                await connect(target_session_attrs=target_attr)
+
+    async def test_prefer_standby_when_standby_is_up(self):
+        con = await self.connect(target_session_attrs='prefer-standby')
+        standby_port = self.standby_cluster.get_connection_spec()['port']
+        connected_host = _get_connected_host(con)
+        self.assertTrue(connected_host.endswith(standby_port))
+        await con.close()
+
+    async def test_prefer_standby_picks_master_when_standby_is_down(self):
+        primary_spec = self.get_cluster_connection_spec(self.master_cluster)
+        connection_spec = {
+            'host': [
+                primary_spec['host'],
+                'unlocalhost',
+            ],
+            'port': [primary_spec['port'], 15345],
+            'database': primary_spec['database'],
+            'user': primary_spec['user'],
+            'target_session_attrs': 'prefer-standby'
+        }
+
+        con = await self.connect(**connection_spec)
+        master_port = self.master_cluster.get_connection_spec()['port']
+        connected_host = _get_connected_host(con)
+        self.assertTrue(connected_host.endswith(master_port))
+        await con.close()
+
+
+def _get_connected_host(con):
+    peername = con._transport.get_extra_info('peername')
+    if isinstance(peername, tuple):
+        peername = "".join((str(s) for s in peername if s))
+    return peername

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -12,7 +12,7 @@ from asyncpg import _testbase as tb
 from asyncpg import connection as apg_con
 
 
-MAX_RUNTIME = 0.1
+MAX_RUNTIME = 0.25
 
 
 class SlowIntrospectionConnection(apg_con.Connection):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -10,7 +10,6 @@ import inspect
 import os
 import platform
 import random
-import sys
 import textwrap
 import time
 import unittest
@@ -741,7 +740,6 @@ class TestPool(tb.ConnectedTestCase):
                         self.assertEqual(pool.get_size(), 3)
                         self.assertEqual(pool.get_idle_size(), 0)
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)
@@ -763,7 +761,6 @@ class TestPool(tb.ConnectedTestCase):
                 async for _ in iterate(con):  # noqa
                     raise MyException()
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_transaction_exit_in_asyncgen_2(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)
@@ -788,7 +785,6 @@ class TestPool(tb.ConnectedTestCase):
 
             del iterator
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_asyncgen_finalization(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -740,6 +740,17 @@ class TestPool(tb.ConnectedTestCase):
                         self.assertEqual(pool.get_size(), 3)
                         self.assertEqual(pool.get_idle_size(), 0)
 
+    async def test_pool_closing(self):
+        async with self.create_pool() as pool:
+            self.assertFalse(pool.is_closing())
+            await pool.close()
+            self.assertTrue(pool.is_closing())
+
+        async with self.create_pool() as pool:
+            self.assertFalse(pool.is_closing())
+            pool.terminate()
+            self.assertTrue(pool.is_closing())
+
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -523,6 +523,7 @@ class TestRecord(tb.ConnectedTestCase):
             record_class=MyRecord,
         )
         self.assertIsInstance(r, MyRecord)
+        self.assertEqual(repr(r), "<MyRecord a=1 b='2'>")
 
         self.assertEqual(list(r.items()), [('a', 1), ('b', '2')])
         self.assertEqual(list(r.keys()), ['a', 'b'])


### PR DESCRIPTION
This should fix the following error seen in one of Noteable's production servers recently:

```
Fatal error: protocol.data_received() call failed.
protocol: <asyncpg.connect_utils.TLSUpgradeProto object at 0x7f7711fd9e70>
transport: <_SelectorSocketTransport fd=653 read=polling write=<idle, bufsize=0>>

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/selector_events.py", line 876, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/srv/noteable/.venv/lib/python3.10/site-packages/asyncpg/connect_utils.py", line 665, in data_received
    self.on_data.set_result(True)
asyncio.exceptions.InvalidStateError: invalid state
```