### PR TITLE
Check whether on_data future is done before setting result/exception

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -661,22 +661,23 @@ class TLSUpgradeProto(asyncio.Protocol):
         self.ssl_is_advisory = ssl_is_advisory
 
     def data_received(self, data):
-        if data == b'S':
-            self.on_data.set_result(True)
-        elif (self.ssl_is_advisory and
-                self.ssl_context.verify_mode == ssl_module.CERT_NONE and
-                data == b'N'):
-            # ssl_is_advisory will imply that ssl.verify_mode == CERT_NONE,
-            # since the only way to get ssl_is_advisory is from
-            # sslmode=prefer. But be extra sure to disallow insecure
-            # connections when the ssl context asks for real security.
-            self.on_data.set_result(False)
-        else:
-            self.on_data.set_exception(
-                ConnectionError(
-                    'PostgreSQL server at "{host}:{port}" '
-                    'rejected SSL upgrade'.format(
-                        host=self.host, port=self.port)))
+        if not self.on_data.done():
+            if data == b'S':
+                self.on_data.set_result(True)
+            elif (self.ssl_is_advisory and
+                    self.ssl_context.verify_mode == ssl_module.CERT_NONE and
+                    data == b'N'):
+                # ssl_is_advisory will imply that ssl.verify_mode == CERT_NONE,
+                # since the only way to get ssl_is_advisory is from
+                # sslmode=prefer. But be extra sure to disallow insecure
+                # connections when the ssl context asks for real security.
+                self.on_data.set_result(False)
+            else:
+                self.on_data.set_exception(
+                    ConnectionError(
+                        'PostgreSQL server at "{host}:{port}" '
+                        'rejected SSL upgrade'.format(
+                            host=self.host, port=self.port)))
 
     def connection_lost(self, exc):
         if not self.on_data.done():


### PR DESCRIPTION
To fix the following error:

```
Fatal error: protocol.data_received() call failed.
protocol: <asyncpg.connect_utils.TLSUpgradeProto object at 0x7f7711fd9e70>
transport: <_SelectorSocketTransport fd=653 read=polling write=<idle, bufsize=0>>

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/selector_events.py", line 876, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/srv/noteable/.venv/lib/python3.10/site-packages/asyncpg/connect_utils.py", line 665, in data_received
    self.on_data.set_result(True)
asyncio.exceptions.InvalidStateError: invalid state
```